### PR TITLE
Compaction

### DIFF
--- a/client/src/transaction.js
+++ b/client/src/transaction.js
@@ -44,7 +44,8 @@ var Transaction = crypton.Transaction = function (session, callback) {
     'addContainerSessionKeyShare',
     'addContainerRecord',
     'addMessage',
-    'deleteMessage'
+    'deleteMessage',
+    'compactContainer'
   ];
 
   // necessary for testing

--- a/server/lib/stores/postgres/sql/setup.sql
+++ b/server/lib/stores/postgres/sql/setup.sql
@@ -599,6 +599,14 @@ create table transaction_add_container_record (
     payload_ciphertext varchar not null
 );
 
+create table transaction_compact_container (
+    id int8 not null primary key default nextval('version_identifier'),
+    transaction_id int8 not null references transaction,
+    name_hmac bytea not null,
+    latest_record_id int8,
+    payload_ciphertext varchar not null
+);
+
 create table transaction_add_message (
     id int8 not null primary key default nextval('version_identifier'),
     transaction_id int8 not null references transaction,

--- a/server/lib/stores/postgres/transaction.js
+++ b/server/lib/stores/postgres/transaction.js
@@ -534,18 +534,15 @@ datastore.transaction.compactContainer = function (data, transaction, callback) 
       var query = {
         /*jslint multistr: true*/
         text: "\
-          insert into transaction_add_container_record \
-          (transaction_id, name_hmac, latest_record_id, \
-          /*hmac, payload_iv, */payload_ciphertext) \
-          values ($1, $2, $3, $4)", // decode($4, 'hex'), \
-          //decode($5, 'hex'), decode($6, 'hex'))",
+          insert into transaction_compact_container \
+          (transaction_id, name_hmac, \
+          latest_record_id, payload_ciphertext) \
+          values ($1, $2, $3, $4)",
         /*jslint multistr: false*/
         values: [
           transaction.transactionId,
           data.containerNameHmac,
           data.latestRecordId,
-          //data.hmac,
-          //data.payloadIv,
           data.payloadCiphertext
         ]
       };


### PR DESCRIPTION
Not done yet, just PRing this for discussion on the API.

Still needs actual record deletion in the transaction SQL, and obviously tests.

I think I've landed on the most basic API I could come up with. `container.compact(callback)` will create a new ultimate record and perform a transaction almost identical to `add_container_record`. It however will only work if the container is fully saved (you can't compactfully save yet, which would be convenient in some situations). The code could be DRYer, but there will be overlap with `save()` with this method. Does this seem alright?