### PR TITLE
Content Security Policy Allow blob: data sources

### DIFF
--- a/ansible/roles/crypton_server/templates/nginx-site.conf.j2
+++ b/ansible/roles/crypton_server/templates/nginx-site.conf.j2
@@ -25,7 +25,7 @@ server {
 
     add_header X-Frame-Options 'SAMEORIGIN';
     add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
-    add_header Content-Security-Policy "default-src 'self'; connect-src wss://localhost localhost; script-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'; object-src 'self'";
+    add_header Content-Security-Policy "default-src 'self' blob:; connect-src wss://localhost localhost; script-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'; object-src 'self'";
     add_header Cache-Control 'no-cache';
 
     rewrite ^/examples/.*/crypton.js /crypton.js;

--- a/server/app.js
+++ b/server/app.js
@@ -76,7 +76,7 @@ if (app.config.securityHeaders) {
     csrf: false,
     csp: {
       policy:{
-        'default-src': "'self'",
+        'default-src': "'self' blob:",
         'connect-src': "wss://localhost localhost",
         'script-src': "'self'",
         'img-src': "'self'",

--- a/server/config/config.test.json
+++ b/server/config/config.test.json
@@ -23,7 +23,7 @@
     "csrf": false,
     "csp": {
       "policy": {
-        "default-src": "'self'",
+        "default-src": "'self' blob:",
         "connect-src": "'self' wss://localhost:1025",
         "script-src": "'self'",
         "img-src": "'self'",


### PR DESCRIPTION
See issue #386

In at least Chrome (46) there is a browser Content Security Policy
violation error on loading the examples from the server.  This is due
to ‘blob:’ being used in the code but not defined as an acceptable data
source.

Example console output:

Refused to create a child context containing
'blob:https%3A//localhost%3A1025/e86679df-de28-4a77-a7db-0029597ff71f'
because it violates the following Content Security Policy directive:
"default-src 'self'". Note that 'child-src' was not explicitly set, so
'default-src' is used as a fallback.
crypton.js:6291

Uncaught SecurityError: Failed to construct 'Worker': Access to the
script at
'blob:https%3A//localhost%3A1025/e86679df-de28-4a77-a7db-0029597ff71f'
is denied by the document's Content Security Policy.
crypton.js:6291

Specifying blob: as a data source is documented here:
https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_dir
ectives#Data