### PR TITLE
Upgrade lusca package (w/ CSRF header fix) from 1.0.x to 1.3.x. Remove crypton checks on Lusca object.

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -57,12 +57,12 @@ app.use(cors({
 if (app.config.securityHeaders) {
   try {
     var luscaObj = app.config.securityHeaders;
-    // A naive validation check:
-    if ((typeof luscaObj.csp == 'object') && (typeof luscaObj.xframe == "string")
-                                          && (typeof luscaObj.csrf == 'boolean')) {
+    app.log("securityHeaders(lusca) config: ", JSON.stringify(luscaObj));
+
+    if (typeof luscaObj == 'object') {
       app.use(appsec(luscaObj));
     } else {
-      throw new Error("Lusca configuration invalid!");
+      throw new Error("securityHeaders must be an Object conforming to the Lusca security config.  See : https://github.com/krakenjs/lusca");
     }
   } catch (ex) {
     app.log("error", ex);

--- a/server/config/config.test.json
+++ b/server/config/config.test.json
@@ -30,12 +30,18 @@
         "style-src": "'self'",
         "font-src": "'self'",
         "object-src": "'self'"
-      }
+      },
+      "reportOnly": false,
+      "reportUri": ""
     },
     "xframe": "SAMEORIGIN",
+    "p3p": false,
     "hsts": {
-      "maxAge": 31536000
-    }
+      "maxAge": 3600,
+      "includeSubDomains": false,
+      "preload": false
+    },
+    "xssProtection": false
   },
   "port": 1025,
   "logLevel": "debug"

--- a/server/package.json
+++ b/server/package.json
@@ -26,7 +26,7 @@
     "cryptojs": "2.5.x",
     "express": "3.5.x",
     "forever": "^0.11.1",
-    "lusca": "1.0.x",
+    "lusca": "1.3.x",
     "node-uuid": "1.4.x",
     "pg": "4.3.x",
     "pg-native": "1.8.x",


### PR DESCRIPTION
Fixes #397 

Prior to this change it was not possible to use the full gammut of config
options for the Lusca security headers package.  For example you could not
pass 'false' to one of the types to disable that type (e.g CSP or HSTS).

Some types just were not validated at all.

Control for where and how to set security headers should always be the
responsibility of the developer. This is especially true for settings like
HSTS which can have severe unintended consequences if configured incorrectly.

In the sample config I added the other Object keys that Lusca accepts
and provided what should be sane defaults to make it easier for a dev to see
what is possible.

Also emitting the current securityHeaders config to STDOUT when the server is run.

I ran the concept of this change by @daviddahl before committing via Twitter DM.