### PR TITLE
Replace use of should.js test assertion lib with chai in server tests.

### DIFF
--- a/README_OSX.md
+++ b/README_OSX.md
@@ -85,6 +85,7 @@ If the output is OK then continue on.
 ````
 cd client
 npm install
+npm install -g karma-cli
 ./compile.sh --once
 ````
 
@@ -100,6 +101,29 @@ cd ../server/
 npm install
 npm link
 crypton-server db:init
+````
+
+### Test the Crypton client code (optional)
+
+PhantomJS Tests
+````
+cd client
+make test
+````
+
+Browser Tests
+````
+cd client
+[edit karma.js.conf to specify which (or all) of Chrome, Firefox, or Safari to test]
+karma start --single-run
+````
+
+### Test the Crypton server code (optional)
+
+Mocha Tests
+````
+cd server
+make test
 ````
 
 ### Run the Crypton Server

--- a/server/package.json
+++ b/server/package.json
@@ -39,7 +39,7 @@
     },
     "devDependencies": {
         "mocha": "2.3.x",
-        "should": "7.1.x"
+        "chai": "3.3.x"
     },
     "optionalDependencies": {},
     "scripts": {

--- a/server/test/account.js
+++ b/server/test/account.js
@@ -20,6 +20,7 @@
 
 var app = require('../app');
 var assert = require('assert');
+var should = require('chai').should();
 var Account = require('../lib/account');
 
 describe('Account model', function () {

--- a/server/test/app.js
+++ b/server/test/app.js
@@ -17,3 +17,5 @@
 */
 
 "use strict";
+
+var should = require('chai').should();

--- a/server/test/datastore.js
+++ b/server/test/datastore.js
@@ -18,8 +18,7 @@
 
 "use strict";
 
-require('should');
-
+var should = require('chai').should();
 var db = require("../lib/storage");
 
 describe("datastore", function () {
@@ -36,7 +35,7 @@ describe("datastore", function () {
         if (err) { return done(err); }
 
         var time = result.rows[0].now;
-        time.should.be.ok;
+        time.should.be.a('Date');
         done();
       });
     });
@@ -45,9 +44,7 @@ describe("datastore", function () {
   it("finds our tables", function (done) {
     db.listTables(function (err, tables) {
       if (err) { return done(err); }
-      tables.should.containEql("account");
-      tables.should.containEql("container");
-      tables.should.containEql("message");
+      tables.should.include.members(["account", "container", "message"]);
       done();
     });
   });

--- a/server/test/messages.js
+++ b/server/test/messages.js
@@ -17,3 +17,5 @@
 */
 
 "use strict";
+
+var should = require('chai').should();

--- a/server/test/session.js
+++ b/server/test/session.js
@@ -18,6 +18,8 @@
 
 "use strict";
 
+var should = require('chai').should();
+
 describe("lib session", function () {
   it("create a new session for an account and return token");
   it("lookup and return a given session by token");

--- a/server/test/transaction.js
+++ b/server/test/transaction.js
@@ -18,6 +18,7 @@
 
 "use strict";
 
+var should = require('chai').should();
 var assert = require('assert');
 var Transaction = require('../lib/transaction');
 

--- a/server/test/z_container.js
+++ b/server/test/z_container.js
@@ -18,6 +18,7 @@
 
 "use strict";
 
+var should = require('chai').should();
 var assert = require('assert');
 var Container = require('../lib/container');
 


### PR DESCRIPTION
This brings both client and server code tests in sync with the same
versions of the same testing libraries (mocha + chai).

Add some brief testing notes to README_OSX.md