### PR TITLE
Semver breaking interface change reqiures minor version  update

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "author": "SpiderOak (https://spideroak.com/)",
   "name": "crypton-server",
   "description": "A zero-knowledge application framework",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "homepage": "https://crypton.io",
   "license": "AGPL-3.0",
   "repository": {


### PR DESCRIPTION
I did not realize that the semver minor version was where the API allows for breaking changes