### PR TITLE
init.js can now be run from anywhere

### DIFF
--- a/server/bin/init.js
+++ b/server/bin/init.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var pg = require('pg').native;
 var config = require('../lib/config');
 var oldConfig;
-var realConfig = JSON.parse(fs.readFileSync('./server/config/config.' + process.env.NODE_ENV + '.json', 'utf8'));
+var realConfig = JSON.parse(fs.readFileSync(__dirname + '/../config/config.' + process.env.NODE_ENV + '.json', 'utf8'));
 var dbConfig = realConfig.database;
 
 function connect(callback) {


### PR DESCRIPTION
init.js pulls config files relative to its file location,
rather than relative to the location from which it's called.