### PR TITLE
Re-factor the db:init, and db:drop scripts to use a postgres superuser and a regular user as appropriate.

### DIFF
--- a/check_dependencies.sh
+++ b/check_dependencies.sh
@@ -44,8 +44,8 @@ if [ $POSTGRES_USER_EXISTS ]; then
   echo "Found postgres user..."
 else
   echo "Configuration issue: the postgres user does not exist in the database, please create it:"
-  echo "  createuser -s -r postgres"
-  echo "is one way to create the postgres user"
+  echo "  createuser --superuser --createrole postgres"
+  echo "is one possible way to create the postgres superuser"
   exit 1;
 fi
 

--- a/server/config/config.development.json
+++ b/server/config/config.development.json
@@ -1,6 +1,8 @@
 {
   "database": {
     "type": "postgres",
+    "postgres_user": "postgres",
+    "postgres_user_password": "",
     "user": "crypton_development_user",
     "password": "crypton_development_user_password",
     "database": "crypton_development",

--- a/server/config/config.test.json
+++ b/server/config/config.test.json
@@ -1,6 +1,8 @@
 {
   "database": {
     "type": "postgres",
+    "postgres_user": "postgres",
+    "postgres_user_password": "",
     "user": "crypton_test_user",
     "password": "crypton_test_user_password",
     "database": "crypton_test",


### PR DESCRIPTION
Fixes #435 

- Users postgres superuser account only for table and user creation and drop. Uses
an environment specific user to create schema's.

- No longer pulls in the config twice in init.js and drop.js

- Clones the env specific config into a normal env specific config, and one that uses
the new postgres user/pass keys.

- Does NOT use sudo on Ubuntu to issue DB commands. Assumes a 'postgres' superuser
has been created (or any superuser account that is configurable now).

- Adds two keys to the environment specific config files for the `postgres`
superuser username and password.  Defaults to 'postgres' and empty password.

- Update the README with:
* Updated NVM install
* Updated Redis install
* Info on how to configure env specific config files.